### PR TITLE
Add auto-deploy pipeline (GitHub Actions + OIDC)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,87 @@
+name: deploy
+
+# Continuous deployment: every push to main builds the site and publishes it to
+# S3 + CloudFront. No AWS keys — the job assumes an OIDC role (infra/github-oidc.tf)
+# whose trust is pinned to this repo's main branch. One-time wiring: `just setup-deploy`.
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'infra/**'
+      - '**/*.md'
+  workflow_dispatch:
+
+permissions:
+  id-token: write # mint the OIDC token used to assume the AWS role
+  contents: read
+  deployments: write # record the publish under the repo's Deployments view
+
+concurrency: deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Skip until the one-time setup runs (`just setup-deploy` sets these repo
+    # variables). Lets this workflow merge to main without a failing red run
+    # before AWS is wired up.
+    if: ${{ vars.AWS_DEPLOY_ROLE_ARN != '' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Build
+        run: bun run build
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Publish to S3
+        env:
+          BUCKET: johncarmack-com-site # fixed name; see infra/variables.tf
+        run: |
+          set -euo pipefail
+          # Content-hashed build assets never change under a given name, so cache
+          # them forever. assets/patterns/* are verbatim public/ files with stable
+          # names, so they're excluded here and revalidated in the next pass.
+          aws s3 sync dist/ "s3://$BUCKET" --delete \
+            --exclude "*" --include "assets/*" --exclude "assets/patterns/*" \
+            --cache-control "public, max-age=31536000, immutable"
+          # Everything else (HTML, icons, manifest, og image, robots, sitemap,
+          # pattern textures) must always revalidate so a deploy is visible at once.
+          aws s3 sync dist/ "s3://$BUCKET" --delete \
+            --exclude "assets/*" --include "assets/patterns/*" \
+            --cache-control "no-cache"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ vars.DISTRIBUTION_ID }}" \
+            --paths "/*"
+
+      # Record the publish as a GitHub Deployment to `production` so the repo's
+      # Deployments view tracks what's live. Done via the API rather than a
+      # job-level `environment:` — that key rewrites the OIDC subject to
+      # repo:…:environment:production, which the role's main-ref trust rejects.
+      - name: Record production deployment
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          body=$(jq -nc --arg ref "$GITHUB_SHA" \
+            '{ref:$ref, environment:"production", production_environment:true, auto_merge:false, required_contexts:[], description:"Published to production"}')
+          id=$(gh api -X POST "repos/$GITHUB_REPOSITORY/deployments" --input - <<<"$body" --jq '.id')
+          gh api -X POST "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" \
+            -f state=success \
+            -f environment=production \
+            -f environment_url=https://johncarmack.com \
+            -f description="Published to production" >/dev/null
+          echo "Recorded production deployment $id"

--- a/infra/README.md
+++ b/infra/README.md
@@ -16,6 +16,7 @@ to the bucket.
   provisions in one apply.
 - `aws_cloudfront_distribution.site` — fronts the bucket, redirect-to-https, compression,
   managed `CachingOptimized` policy, SPA fallback (403/404 → `/index.html`).
+- `aws_iam_role.deploy` (`github-actions-johncarmack-com-deploy`) — the OIDC role the deploy workflow assumes; trust pinned to this repo's `main`, permissions scoped to S3 site sync + CloudFront invalidation. Reuses the account's shared GitHub OIDC provider (referenced as a `data` source, created by `my-infra/github-oidc`).
 
 The **live** A/CNAME records (`johncarmack.com` → this distribution) stay in the
 `dns` root of `my-infra-private`, which owns all hosted-zone records account-wide.
@@ -34,7 +35,16 @@ State: `s3://john-carmack-terraform-state/johncarmack.com/terraform.tfstate`.
 
 ## Deploy the site
 
-From the repo root (uses the Terraform outputs):
+Pushing to `main` deploys automatically: `.github/workflows/deploy.yml` builds the site and assumes the OIDC deploy role to sync S3 and invalidate CloudFront — no AWS keys in CI.
+
+One-time wiring (creates the deploy role, then sets the `AWS_DEPLOY_ROLE_ARN` and `DISTRIBUTION_ID` repo variables the workflow reads):
+
+```sh
+export AWS_PROFILE=newearth-admin   # account 735853783919
+just setup-deploy
+```
+
+Manual fallback — publish the local build straight from your machine:
 
 ```sh
 just deploy        # bun run build + s3 sync + CloudFront invalidation

--- a/infra/github-oidc.tf
+++ b/infra/github-oidc.tf
@@ -1,0 +1,82 @@
+# GitHub Actions deploy role for johncarmack1984/johncarmack.com (OIDC, no keys).
+#
+# Reuses the account's single GitHub OIDC provider (created by the public
+# my-infra/github-oidc root), referenced here as a data source. Trust is pinned
+# to this repo's main branch; the role may sync the site bucket and invalidate
+# the distribution — nothing else. Applied once locally with admin creds
+# (AWS_PROFILE=newearth-admin) via `just setup-deploy`; the deploy workflow then
+# assumes it from CI. The workflow does NOT run Terraform, so co-locating this
+# role with the resources it grants on (s3.tf / cdn.tf) is safe.
+
+locals {
+  github_repo = "johncarmack1984/johncarmack.com"
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "deploy_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # Only the main branch (push or workflow_dispatch on main) may assume this.
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${local.github_repo}:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "deploy" {
+  name                 = "github-actions-johncarmack-com-deploy"
+  description          = "Deploy role for GitHub Actions in ${local.github_repo} (OIDC): S3 site sync + CloudFront invalidation"
+  assume_role_policy   = data.aws_iam_policy_document.deploy_trust.json
+  max_session_duration = 3600
+}
+
+data "aws_iam_policy_document" "deploy" {
+  statement {
+    sid       = "ListSiteBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.site.arn]
+  }
+
+  statement {
+    sid    = "WriteSiteObjects"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = ["${aws_s3_bucket.site.arn}/*"]
+  }
+
+  statement {
+    sid       = "InvalidateDistribution"
+    effect    = "Allow"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = [aws_cloudfront_distribution.site.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "deploy" {
+  name   = "site-deploy"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.deploy.json
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -12,3 +12,8 @@ output "distribution_domain_name" {
   description = "CloudFront domain — verify the site here before cutting over DNS."
   value       = aws_cloudfront_distribution.site.domain_name
 }
+
+output "deploy_role_arn" {
+  description = "Set as the AWS_DEPLOY_ROLE_ARN repo variable for the deploy workflow."
+  value       = aws_iam_role.deploy.arn
+}

--- a/justfile
+++ b/justfile
@@ -5,13 +5,24 @@ build:
     bun install
     bun run build
 
-# Build, then publish dist/ to S3 and invalidate the CloudFront cache.
+# Manual publish. The deploy workflow (.github/workflows/deploy.yml) does this
+# automatically on every push to main; this stays as a local fallback.
 # Requires AWS_PROFILE=newearth-admin and `terraform -chdir=infra init` already run.
 deploy: build
     aws s3 sync dist/ "s3://$(terraform -chdir=infra output -raw bucket)" --delete
     aws cloudfront create-invalidation \
         --distribution-id "$(terraform -chdir=infra output -raw distribution_id)" \
         --paths "/*"
+
+# One-time: create the GitHub Actions OIDC deploy role (infra/github-oidc.tf) and
+# wire the two repo variables the deploy workflow reads. Needs AWS_PROFILE=newearth-admin
+# and an authenticated gh CLI. Re-runnable; review the plan before approving.
+setup-deploy:
+    terraform -chdir=infra init
+    terraform -chdir=infra apply
+    gh variable set AWS_DEPLOY_ROLE_ARN --body "$(terraform -chdir=infra output -raw deploy_role_arn)"
+    gh variable set DISTRIBUTION_ID --body "$(terraform -chdir=infra output -raw distribution_id)"
+    @echo "Done. Push to main or run 'gh workflow run deploy.yml' to deploy."
 
 # Show the CloudFront domain to verify against before the DNS cutover.
 url:


### PR DESCRIPTION
Push to `main` now builds and publishes the site to S3 + CloudFront automatically — no more manual `just deploy`.

- `.github/workflows/deploy.yml` — build (bun) → `aws s3 sync` (hashed assets immutable, everything else no-cache) → CloudFront invalidation. Auth via OIDC role assumption; no long-lived keys. Job is guarded by `if: vars.AWS_DEPLOY_ROLE_ARN != ''` so it skips cleanly until setup runs.
- `infra/github-oidc.tf` — the OIDC deploy role, trust pinned to this repo's `main`, scoped to S3 sync + CloudFront invalidation. Reuses the account's shared OIDC provider (data source), matching the `lauren-urban-archive/github-oidc` pattern.
- `just setup-deploy` — one-time: applies the role and sets the `AWS_DEPLOY_ROLE_ARN` + `DISTRIBUTION_ID` repo variables.

Verified: `terraform validate` passes, fmt canonical, workflow YAML parses.