### PR TITLE
Add PR CI checks + trim deploy invalidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+# PR gate: typecheck + build the app and check the Terraform before merge to main.
+# No deploy and no AWS credentials — purely correctness checks.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Build
+        run: bun run build
+
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v3
+      - name: Format
+        run: terraform -chdir=infra fmt -check -recursive
+      - name: Validate
+        # -backend=false validates the config without touching remote state, so
+        # this needs no AWS credentials.
+        run: |
+          terraform -chdir=infra init -backend=false
+          terraform -chdir=infra validate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,10 +61,14 @@ jobs:
             --cache-control "no-cache"
 
       - name: Invalidate CloudFront
+        # Only the SPA entry needs busting: hashed assets are immutable and
+        # content-addressed (a new build ships new filenames, so stale entries
+        # just go unreferenced), and the other root files are served no-cache so
+        # CloudFront revalidates them on its own.
         run: |
           aws cloudfront create-invalidation \
             --distribution-id "${{ vars.DISTRIBUTION_ID }}" \
-            --paths "/*"
+            --paths "/" "/index.html"
 
       # Record the publish as a GitHub Deployment to `production` so the repo's
       # Deployments view tracks what's live. Done via the API rather than a

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ deploy: build
     aws s3 sync dist/ "s3://$(terraform -chdir=infra output -raw bucket)" --delete
     aws cloudfront create-invalidation \
         --distribution-id "$(terraform -chdir=infra output -raw distribution_id)" \
-        --paths "/*"
+        --paths "/" "/index.html"
 
 # One-time: create the GitHub Actions OIDC deploy role (infra/github-oidc.tf) and
 # wire the two repo variables the deploy workflow reads. Needs AWS_PROFILE=newearth-admin


### PR DESCRIPTION
Two follow-ups:

- **`ci.yml`** — on every PR to `main`: `web` job (bun → typecheck → build) and `terraform` job (`fmt -check` + `init -backend=false` + `validate`). No deploy, no AWS credentials; keeps `main` green before merge.
- **Deploy invalidation** trimmed from `/*` to `/` + `/index.html` (workflow + `just deploy`). Hashed assets are immutable/content-addressed so they never need busting, and other root files are `no-cache` so they revalidate automatically — only the SPA entry document needs an explicit invalidation.

This PR exercises the new CI on itself.