### PR TITLE
Fold remaining tools into project badges

### DIFF
--- a/src/components/projects/project.tsx
+++ b/src/components/projects/project.tsx
@@ -50,7 +50,7 @@ function Project({
           />
         </a>
         <CardTitle className="mt-4 text-base font-semibold">{title}</CardTitle>
-        <div className="flex gap-2">{skills.map(ProjectSkill)}</div>
+        <div className="flex flex-wrap gap-2">{skills.map(ProjectSkill)}</div>
       </CardHeader>
       <CardContent className="text-sm">{description}</CardContent>
 

--- a/src/components/projects/projects.tsx
+++ b/src/components/projects/projects.tsx
@@ -8,9 +8,12 @@ import typedGeojson from "@/assets/img/typed-geojson.webp";
 
 import AppleIcon from "@/components/ui/icons/apple";
 import AwsIcon from "@/components/ui/icons/aws";
+import AxumIcon from "@/components/ui/icons/axum";
+import CdkIcon from "@/components/ui/icons/cdk";
 import CodeIcon from "@/components/ui/icons/code";
 import CommandPromptIcon from "@/components/ui/icons/command";
 import DeckGlIcon from "@/components/ui/icons/deckgl";
+import LumaGlIcon from "@/components/ui/icons/lumagl";
 import MapLibreIcon from "@/components/ui/icons/maplibre";
 import NextJsIcon from "@/components/ui/icons/nextjs";
 import ReactIcon from "@/components/ui/icons/react";
@@ -40,7 +43,9 @@ const projects = [
       DeckGlIcon,
       MapLibreIcon,
       WebGlIcon,
+      LumaGlIcon,
       AwsIcon,
+      CdkIcon,
     ],
   },
   {
@@ -49,7 +54,7 @@ const projects = [
     image: deckWindLayer,
     href: "https://github.com/johncarmack1984/deck-wind-layer",
     platforms: [WebIcon],
-    skills: [TypeScriptIcon, DeckGlIcon, WebGlIcon, ViteIcon],
+    skills: [TypeScriptIcon, DeckGlIcon, WebGlIcon, LumaGlIcon, ViteIcon],
   },
   {
     title: "Manifest",
@@ -57,7 +62,16 @@ const projects = [
     image: manifest,
     href: "https://github.com/johncarmack1984/manifest",
     platforms: [WebIcon],
-    skills: [Rust, TypeScriptIcon, ReactIcon, TailwindIcon, ViteIcon, AwsIcon],
+    skills: [
+      Rust,
+      AxumIcon,
+      TypeScriptIcon,
+      ReactIcon,
+      TailwindIcon,
+      ViteIcon,
+      AwsIcon,
+      CdkIcon,
+    ],
   },
   {
     title: "typed-geojson",
@@ -81,7 +95,16 @@ const projects = [
     image: lux,
     href: "https://github.com/johncarmack1984/lux",
     platforms: [AppleIcon],
-    skills: [Rust, TypeScriptIcon, ReactIcon, NextJsIcon, TailwindIcon, TauriIcon],
+    skills: [
+      Rust,
+      AxumIcon,
+      TypeScriptIcon,
+      ReactIcon,
+      NextJsIcon,
+      TailwindIcon,
+      TauriIcon,
+      TerraformIcon,
+    ],
   },
   {
     title: "Deep Freeze",

--- a/src/components/ui/icons/axum.tsx
+++ b/src/components/ui/icons/axum.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+import type { SkillIcon } from "@/components/skills/skill";
+
+// Axum has no brand mark — stacked service bars, for a Rust web/API server.
+const AxumIcon: SkillIcon = ({ className, ...props }) => {
+  return (
+    <svg viewBox="0 0 24 24" className={cn(className)} {...props}>
+      <title>Axum</title>
+      <rect x="3" y="5.5" width="18" height="5" rx="2.5"></rect>
+      <rect x="3" y="13.5" width="18" height="5" rx="2.5"></rect>
+    </svg>
+  );
+};
+
+export default AxumIcon;

--- a/src/components/ui/icons/cdk.tsx
+++ b/src/components/ui/icons/cdk.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+import type { SkillIcon } from "@/components/skills/skill";
+
+// AWS CDK has no monochrome brand mark — two stacked tiles, for composable constructs.
+const CdkIcon: SkillIcon = ({ className, ...props }) => {
+  return (
+    <svg viewBox="0 0 24 24" className={cn(className)} {...props}>
+      <title>AWS CDK</title>
+      <rect x="7" y="4" width="13" height="13" rx="2"></rect>
+      <rect x="4" y="7" width="13" height="13" rx="2"></rect>
+    </svg>
+  );
+};
+
+export default CdkIcon;

--- a/src/components/ui/icons/lumagl.tsx
+++ b/src/components/ui/icons/lumagl.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+import type { SkillIcon } from "@/components/skills/skill";
+
+// luma.gl has no brand mark — a triangle, the GPU rendering primitive it sits on.
+const LumaGlIcon: SkillIcon = ({ className, ...props }) => {
+  return (
+    <svg viewBox="0 0 24 24" className={cn(className)} {...props}>
+      <title>luma.gl</title>
+      <path d="M12 3 L21 20 L3 20 Z"></path>
+    </svg>
+  );
+};
+
+export default LumaGlIcon;


### PR DESCRIPTION
Per request, badges now show every meaningful tool, not just the ones with brand logos:

- luma.gl → Stormdeck, deck-wind-layer
- AWS CDK → Stormdeck, Manifest
- Axum → Manifest, Lux
- Terraform → Lux

luma.gl/CDK/Axum have no brand marks anywhere (not in simple-icons), so they use simple monochrome glyphs (triangle / stacked tiles / service bars). Added `flex-wrap` to the badge row for the denser cards (Stormdeck now has 11). Typecheck + build pass.