### PR TITLE
Fix README stack: Vite + React on S3/CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 The source code for [johncarmack.com](https://johncarmack.com).
 
-- NextJS
-- ShadCN
-- Bun
-- Tailwind 4 Alpha
-- Vercel
+- Vite + React + TypeScript
+- shadcn/ui
+- Tailwind CSS v4
+- Deployed to AWS S3 + CloudFront via GitHub Actions (OIDC, no static keys); infrastructure managed with Terraform
 
 Aiming for high Google Lighthouse scores and good SEO.


### PR DESCRIPTION
The README listed Next.js / Bun / Vercel, but the site is actually Vite + React + TypeScript (shadcn/ui, Tailwind v4), deployed to AWS S3 + CloudFront via GitHub Actions (OIDC, no static keys) with Terraform-managed infra. Updates the stack list to match what ships.
