### PR TITLE
chore: drop em-dashes from icon comments

### DIFF
--- a/src/components/ui/icons/axum.tsx
+++ b/src/components/ui/icons/axum.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { SkillIcon } from "@/components/skills/skill";
 
-// Axum has no brand mark — stacked service bars, for a Rust web/API server.
+// Axum has no brand mark: stacked service bars, for a Rust web/API server.
 const AxumIcon: SkillIcon = ({ className, ...props }) => {
   return (
     <svg viewBox="0 0 24 24" className={cn(className)} {...props}>

--- a/src/components/ui/icons/cdk.tsx
+++ b/src/components/ui/icons/cdk.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { SkillIcon } from "@/components/skills/skill";
 
-// AWS CDK has no monochrome brand mark — two stacked tiles, for composable constructs.
+// AWS CDK has no monochrome brand mark: two stacked tiles, for composable constructs.
 const CdkIcon: SkillIcon = ({ className, ...props }) => {
   return (
     <svg viewBox="0 0 24 24" className={cn(className)} {...props}>

--- a/src/components/ui/icons/deckgl.tsx
+++ b/src/components/ui/icons/deckgl.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { SkillIcon } from "@/components/skills/skill";
 
-// deck.gl has no monochrome brand mark, so this is a flat-top hexagon "cell" —
+// deck.gl has no monochrome brand mark, so this is a flat-top hexagon "cell",
 // its signature HexagonLayer bin. The skill label spells out the name.
 const DeckGlIcon: SkillIcon = ({ className, ...props }) => {
   return (

--- a/src/components/ui/icons/lumagl.tsx
+++ b/src/components/ui/icons/lumagl.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { SkillIcon } from "@/components/skills/skill";
 
-// luma.gl has no brand mark — a triangle, the GPU rendering primitive it sits on.
+// luma.gl has no brand mark: a triangle, the GPU rendering primitive it sits on.
 const LumaGlIcon: SkillIcon = ({ className, ...props }) => {
   return (
     <svg viewBox="0 0 24 24" className={cn(className)} {...props}>


### PR DESCRIPTION
Replaces the em-dashes in the four SVG icon comments (deck.gl, AWS CDK, Axum, luma.gl) with commas/colons. Comment-only; the built bundle is unchanged (esbuild strips comments). Keeps the repo source uniformly em-dash-free.