### PR TITLE
head: lead with LLM + geospatial, add Person schema + canonical

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <title>John Carmack - Senior Software Engineer</title>
+    <title>John Carmack - AI/LLM & Geospatial Software Engineer</title>
     <meta
       name="description"
-      content="Senior full-stack engineer -- Rust and TypeScript, from GPU and geospatial front ends to cloud infrastructure."
+      content="Software engineer focused on production LLM/AI systems and geospatial/GPU visualization: deck.gl, luma.gl, Rust. Remote, building data-heavy products end to end."
     />
     <meta
       name="keywords"
-      content="John Carmack, Software Engineer, Senior Software Engineer, Rust, TypeScript, JavaScript, React, Tauri, MapLibre, deck.gl, geospatial, AWS, full-stack"
+      content="John Carmack, johncarmack1984, AI engineer, LLM engineer, production LLM, AI systems, geospatial engineer, deck.gl, luma.gl, GPU, WebGL, Rust, TypeScript, MapLibre, Tauri, AWS"
     />
     <meta name="author" content="John Carmack" />
     <meta
@@ -36,22 +36,45 @@
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:url" content="https://johncarmack.com" />
-    <meta property="og:site_name" content="John Carmack - Senior Software Engineer" />
-    <meta property="og:title" content="John Carmack - Senior Software Engineer" />
+    <meta property="og:site_name" content="John Carmack - AI/LLM & Geospatial Software Engineer" />
+    <meta property="og:title" content="John Carmack - AI/LLM & Geospatial Software Engineer" />
     <meta
       property="og:description"
-      content="Senior full-stack engineer -- Rust and TypeScript, from GPU and geospatial front ends to cloud infrastructure."
+      content="Software engineer focused on production LLM/AI systems and geospatial/GPU visualization: deck.gl, luma.gl, Rust. Remote, building data-heavy products end to end."
     />
     <meta property="og:image" content="/opengraph-image.png" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="John Carmack - Senior Software Engineer" />
+    <meta name="twitter:title" content="John Carmack - AI/LLM & Geospatial Software Engineer" />
     <meta
       name="twitter:description"
-      content="Senior full-stack engineer -- Rust and TypeScript, from GPU and geospatial front ends to cloud infrastructure."
+      content="Software engineer focused on production LLM/AI systems and geospatial/GPU visualization: deck.gl, luma.gl, Rust. Remote, building data-heavy products end to end."
     />
     <meta name="twitter:image" content="/opengraph-image.png" />
+
+    <link rel="canonical" href="https://johncarmack.com/" />
+
+    <!-- Person / ProfilePage entity: gives Google + LLM answer engines a clean
+         "who is this" and disambiguates from the id Software / Oculus namesake.
+         Static here so crawlers and non-JS LLM bots see it without prerendering. -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "ProfilePage",
+        "mainEntity": {
+          "@type": "Person",
+          "name": "John Carmack",
+          "alternateName": "johncarmack1984",
+          "url": "https://johncarmack.com/",
+          "jobTitle": "AI/LLM & Geospatial Software Engineer",
+          "description": "Software engineer focused on production LLM/AI systems and geospatial/GPU data visualization with deck.gl, luma.gl, and Rust.",
+          "disambiguatingDescription": "A software engineer (GitHub: johncarmack1984) focused on AI/LLM and geospatial/GPU engineering. Not the id Software / Oculus founder of the same name.",
+          "knowsAbout": ["Large language models", "Production AI systems", "Retrieval-augmented generation", "Geospatial data visualization", "deck.gl", "luma.gl", "GPU rendering", "WebGL", "Rust", "TypeScript"],
+          "sameAs": ["https://github.com/johncarmack1984"]
+        }
+      }
+    </script>
 
     <!-- Inter, matching the previous next/font setup -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
First SEO/GEO fix to the site head, addressing the highest-severity findings from a structural audit.

- Empty entity for crawlers/LLMs -> adds a static `Person` / `ProfilePage` JSON-LD block. Because it is static in `index.html`, search crawlers and non-JS LLM answer engines see it without any prerendering. Includes a `disambiguatingDescription` that separates this John Carmack (GitHub: johncarmack1984; AI/LLM + geospatial) from the id Software / Oculus namesake.
- Generic positioning -> title and meta now lead with production-LLM/AI and keep geospatial/GPU as the differentiator, instead of "Senior Software Engineer".
- No canonical -> adds `rel=canonical`.

Follow-up (separate PR): prerender / SSG the route so the visible body content, not just the head, is in the server HTML. The served HTML currently has about 6 words of body text, so the page body is invisible to non-JS crawlers; this PR fixes the entity, title, and description layer first.
