### PR TITLE
schema: add LinkedIn to Person sameAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
           "description": "Software engineer focused on production LLM/AI systems and geospatial/GPU data visualization with deck.gl, luma.gl, and Rust.",
           "disambiguatingDescription": "A software engineer (GitHub: johncarmack1984) focused on AI/LLM and geospatial/GPU engineering. Not the id Software / Oculus founder of the same name.",
           "knowsAbout": ["Large language models", "Production AI systems", "Retrieval-augmented generation", "Geospatial data visualization", "deck.gl", "luma.gl", "GPU rendering", "WebGL", "Rust", "TypeScript"],
-          "sameAs": ["https://github.com/johncarmack1984"]
+          "sameAs": ["https://github.com/johncarmack1984", "https://www.linkedin.com/in/johncarmack1984"]
         }
       }
     </script>


### PR DESCRIPTION
Adds the LinkedIn profile to the Person `sameAs` array, strengthening entity disambiguation from the namesake. One-line, additive.