### PR TITLE
Lead with LLM/AI + geo, keep aviation searchable

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           "jobTitle": "AI/LLM & Geospatial Software Engineer",
           "description": "Software engineer focused on production LLM/AI systems and geospatial/GPU data visualization with deck.gl, luma.gl, and Rust.",
           "disambiguatingDescription": "A software engineer (GitHub: johncarmack1984) focused on AI/LLM and geospatial/GPU engineering. Not the id Software / Oculus founder of the same name.",
-          "knowsAbout": ["Large language models", "Production AI systems", "Retrieval-augmented generation", "Geospatial data visualization", "deck.gl", "luma.gl", "GPU rendering", "WebGL", "Rust", "TypeScript"],
+          "knowsAbout": ["Large language models", "Production AI systems", "Retrieval-augmented generation", "Geospatial data visualization", "deck.gl", "luma.gl", "GPU rendering", "WebGL", "Aviation software", "Electronic flight bag (EFB)", "Flight planning systems", "Safety-critical systems", "Rust", "TypeScript"],
           "sameAs": ["https://github.com/johncarmack1984", "https://www.linkedin.com/in/johncarmack1984"]
         }
       }

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -9,10 +9,11 @@ function HeroText() {
         Hi. I'm John Carmack.
       </h1>
       <p className="text-muted-foreground text-lg">
-        I'm a senior full-stack engineer: Rust and TypeScript, GPU and
-        geospatial front ends to cloud infrastructure. Recently the primary
-        author of a safety-critical desktop aviation application and lone
-        architect of a real-time analytics platform.
+        I'm a software engineer focused on production LLM/AI and geospatial/GPU
+        systems: Rust and TypeScript, deck.gl and luma.gl to cloud
+        infrastructure. Recently the primary author of a safety-critical
+        aviation desktop application and the lone architect of a real-time
+        analytics platform.
       </p>
     </div>
   );


### PR DESCRIPTION
Positioning follow-up to the prerender PR (#18), backed by a GEO probe across 4 answer engines.

## Why
Now that the body is crawler/LLM-visible, the hero copy is what gets read. It led with "senior full-stack engineer" (off the AI/LLM lane). A GEO probe also confirmed that the bare name **"John Carmack aviation" conflates hard with the aerospace-famous namesake** (Armadillo Aerospace) on parametric LLMs, while web-grounded engines (Perplexity) resolve the real entity correctly via LinkedIn/GitHub. So: keep aviation (it is a real target: ForeFlight / FlightAware are geospatial-aviation), but anchor it to the specific long-tail rather than the bare name.

## What
- **Hero copy** leads with production LLM/AI and geospatial/GPU, and keeps the **safety-critical aviation desktop app** clause (colon instead of em-dash, per house style).
- **Person `knowsAbout`** extended with `Aviation software`, `Electronic flight bag (EFB)`, `Flight planning systems`, `Safety-critical systems` — structured, LLM-legible, no competition for title space.

## Verified
- `dist/index.html` has the new copy (old "senior full-stack engineer" gone) and the aviation `knowsAbout` terms in the head.
- Hydration gate (headless Chrome): 0 errors / 0 warnings / 0 mismatches, fiber attached, theme toggle works.
- `typecheck` + `build` pass.