### PR TITLE
LCP: prioritize hero portrait, lazy-load backgrounds + cards

### DIFF
--- a/src/components/hero/image-background.tsx
+++ b/src/components/hero/image-background.tsx
@@ -53,6 +53,8 @@ function HeroImageBackground() {
         )}
         src={day}
         alt="Day Theme Backdrop"
+        loading="lazy"
+        fetchPriority="low"
       />
       <img
         className={cn(
@@ -60,6 +62,8 @@ function HeroImageBackground() {
         )}
         src={night}
         alt="Night Theme Backdrop"
+        loading="lazy"
+        fetchPriority="low"
       />
     </>
   );

--- a/src/components/hero/image.tsx
+++ b/src/components/hero/image.tsx
@@ -6,7 +6,12 @@ function HeroImage() {
   return (
     <div className="relative z-10 basis-1/3 overflow-clip transition">
       <HeroImageBackground />
-      <img className="relative z-20 h-auto w-full" src={john} alt="John Carmack" />
+      <img
+        className="relative z-20 h-auto w-full"
+        src={john}
+        alt="John Carmack"
+        fetchPriority="high"
+      />
     </div>
   );
 }

--- a/src/components/projects/project.tsx
+++ b/src/components/projects/project.tsx
@@ -44,6 +44,7 @@ function Project({
         <a aria-label={title} href={href}>
           <img
             alt={title}
+            loading="lazy"
             className="aspect-video h-32 w-full rounded-md object-cover transition-transform duration-500 hover:scale-105"
             src={image}
             style={{


### PR DESCRIPTION
Follow-up to the prerender PR. After prerendering, PSI LCP was 3.8s ("needs improvement"). A throttled-mobile LCP probe (Chrome over CDP) found the cause: the decorative day/night hero backgrounds render the **same size** as the portrait but are heavier (389KB / 250KB vs 157KB), so they were intermittently **winning the LCP race** (~7.6s when a background was the LCP element, ~5.4s when the portrait was) and React 19 was preloading all of them plus the 12 below-fold project images.

## Changes
- **Hero day/night backgrounds** -> `loading="lazy"` + `fetchPriority="low"`: they drop out of React 19 preload and stop being LCP candidates (they sit behind the portrait, purely decorative).
- **Hero portrait (john.webp)** -> `fetchPriority="high"`: becomes the consistent, prioritized LCP element.
- **12 project-card images** (below fold) -> `loading="lazy"`: drop their preloads, free bandwidth for the hero.

## Verified (throttled mobile, Chrome CDP)
- Preload `<link>` count: **13 -> 1** (only the portrait).
- LCP element: was flipping portrait/background, now **consistently the portrait**.
- LCP: ~5.4-7.6s -> **~3.37s, stable across 3 runs** (local throttle is harsher than PSI; the delta + consistency are the point).
- Hydration gate: 0 errors / 0 warnings / 0 mismatches; theme toggle still works with lazy backgrounds.

Real PSI number to follow post-deploy. Remaining lever for <2.5s after this: compress/resize the 157KB portrait itself.