### PR TITLE
Reserve hero image dimensions to prevent CLS

### DIFF
--- a/src/components/hero/image-background.tsx
+++ b/src/components/hero/image-background.tsx
@@ -53,6 +53,8 @@ function HeroImageBackground() {
         )}
         src={day}
         alt="Day Theme Backdrop"
+        width={1005}
+        height={902}
         loading="lazy"
         fetchPriority="low"
       />
@@ -62,6 +64,8 @@ function HeroImageBackground() {
         )}
         src={night}
         alt="Night Theme Backdrop"
+        width={1005}
+        height={902}
         loading="lazy"
         fetchPriority="low"
       />

--- a/src/components/hero/image.tsx
+++ b/src/components/hero/image.tsx
@@ -10,6 +10,8 @@ function HeroImage() {
         className="relative z-20 h-auto w-full"
         src={john}
         alt="John Carmack"
+        width={1005}
+        height={902}
         fetchPriority="high"
       />
     </div>


### PR DESCRIPTION
PSI (`unsized-images` audit) flagged the hero portrait `<img ... src=".../john.avif">` as having no dimensions, which produced **variable CLS (0 → 0.315 run-to-run)** on real-world latency — it does not reproduce on localhost because assets arrive too fast to open a shift window.

Adds intrinsic `width={1005} height={902}` to the portrait and both day/night backgrounds. The browser uses these to reserve the correct aspect-ratio box before the image loads; `w-full h-auto` still controls the rendered size, so **no visual change**.

Verified: typecheck + build pass, hydration gate clean, local CLS 0, LCP unchanged. Live PSI CLS to confirm post-merge.