### PR TITLE
font-display: optional to eliminate web-font CLS

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=optional"
       rel="stylesheet"
     />
 


### PR DESCRIPTION
PSI's `layout-shifts` audit attributes the page CLS (variable, **up to 0.315**) to **"Web font loaded"** -- Inter (Google Fonts, `display=swap`) arrives late and reflows the text. The hero images were not the cause (the earlier `unsized-images` fix was correct hygiene but did not move CLS).

`display=swap` permits the late swap-in that shifts layout. `display=optional` is spec-guaranteed never to swap after the ~100ms block period, so it **cannot** cause a layout shift. Inter is metrically close to the system-ui fallback, so the visual cost is negligible; on repeat visits the cached font renders from first paint.

This does not remove the render-blocking Google Fonts request (a separate LCP lever -- self-hosting Inter would address that). Verifying CLS + FCP/LCP on live PSI post-merge.