### PR TITLE
Lazy-load the theme-toggle dropdown (-16KB gz initial JS)

### DIFF
--- a/src/components/theme-toggle-menu.tsx
+++ b/src/components/theme-toggle-menu.tsx
@@ -1,0 +1,62 @@
+import useSunHidden from "@/hooks/useSunHidden";
+import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+// Heavy half of the theme toggle: the Radix dropdown (~17KB gz of popper/focus/
+// portal machinery). Lives in its own chunk, loaded on first interaction from
+// theme-toggle.tsx, so it stays out of the initial bundle.
+const iconVariants = cva(
+  ["absolute", "size-[1.2rem]", "transition-transform"],
+  {
+    variants: {
+      hidden: {
+        true: ["opacity-0", "-rotate-180"],
+        false: ["opacity-100", "rotate-0"],
+      },
+    },
+    defaultVariants: {
+      hidden: true,
+    },
+  },
+);
+
+export default function ThemeMenu({
+  sunHidden,
+  defaultOpen,
+}: {
+  sunHidden: boolean;
+  defaultOpen?: boolean;
+}) {
+  const { setTheme } = useSunHidden();
+  return (
+    <DropdownMenu defaultOpen={defaultOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button className="bg-background/20" variant="outline" size="icon">
+          <SunIcon className={cn(iconVariants({ hidden: sunHidden }))} />
+          <MoonIcon className={cn(iconVariants({ hidden: !sunHidden }))} />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,17 +1,10 @@
-
-import * as React from "react";
+import { lazy, Suspense, useState, type ComponentProps } from "react";
 import useSunHidden from "@/hooks/useSunHidden";
 import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
 import { cva } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 
 const iconVariants = cva(
   ["absolute", "size-[1.2rem]", "transition-transform"],
@@ -28,28 +21,46 @@ const iconVariants = cva(
   },
 );
 
-export default function ModeToggle() {
-  const { sunHidden, setTheme } = useSunHidden();
+// The light/dark/system menu pulls in the Radix dropdown (~17KB gz). Defer it to
+// a chunk loaded on first interaction, so it stays out of the initial bundle.
+// hover/focus warms the chunk cache (without unmounting the interactive trigger,
+// so a click is never lost); the click mounts the menu, which opens via defaultOpen.
+const ThemeMenu = lazy(() => import("./theme-toggle-menu"));
+const preloadMenu = () => {
+  void import("./theme-toggle-menu");
+};
+
+function TriggerButton({
+  sunHidden,
+  ...props
+}: { sunHidden: boolean } & ComponentProps<typeof Button>) {
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button className="bg-background/20" variant="outline" size="icon">
-          <SunIcon className={cn(iconVariants({ hidden: sunHidden }))} />
-          <MoonIcon className={cn(iconVariants({ hidden: !sunHidden }))} />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme("light")}>
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Dark
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("system")}>
-          System
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button className="bg-background/20" variant="outline" size="icon" {...props}>
+      <SunIcon className={cn(iconVariants({ hidden: sunHidden }))} />
+      <MoonIcon className={cn(iconVariants({ hidden: !sunHidden }))} />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}
+
+export default function ModeToggle() {
+  const { sunHidden } = useSunHidden();
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <TriggerButton
+        sunHidden={sunHidden}
+        onPointerEnter={preloadMenu}
+        onFocus={preloadMenu}
+        onClick={() => setOpen(true)}
+      />
+    );
+  }
+
+  return (
+    <Suspense fallback={<TriggerButton sunHidden={sunHidden} />}>
+      <ThemeMenu sunHidden={sunHidden} defaultOpen />
+    </Suspense>
   );
 }


### PR DESCRIPTION
The Radix `dropdown-menu` (popper/focus-scope/portal machinery, ~16KB gz) was in the initial bundle but is used by exactly one thing: the light/dark/system theme toggle. This was the bulk of the "Reduce unused JavaScript" finding.

Splits it into an on-demand chunk (same pattern as the mobile menu panel). hover/focus warms the module cache while the interactive trigger stays mounted (so a click during load is never lost); the click mounts the menu, which opens via `defaultOpen`.

- Initial JS: **129.5 -> 113.5KB gz** (-16KB); unused-JS 49 -> 39KB.
- Theme toggle behavior + Radix a11y unchanged (CDP gate: opens, 3 items, theme changes).
- Chunk is not modulepreloaded (loads only on interaction).