### PR TITLE
ci: pin actions, add timeouts, pin terraform version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot version updates. Security updates (the alerts) are a separate repo
+# setting and stay on. This keeps the SHA-pinned actions current -- Dependabot
+# bumps the pin and its version comment together.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,10 @@ permissions:
 jobs:
   web:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install --frozen-lockfile
       - name: Typecheck
         run: bun run typecheck
@@ -27,9 +28,12 @@ jobs:
 
   terraform:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: hashicorp/setup-terraform@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: 1.15.7
       - name: Format
         run: terraform -chdir=infra fmt -check -recursive
       - name: Validate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,14 +21,15 @@ concurrency: deploy
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Skip until the one-time setup runs (`just setup-deploy` sets these repo
     # variables). Lets this workflow merge to main without a failing red run
     # before AWS is wired up.
     if: ${{ vars.AWS_DEPLOY_ROLE_ARN != '' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - run: bun install --frozen-lockfile
 
@@ -38,7 +39,7 @@ jobs:
       - name: Build
         run: bun run build
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-east-1


### PR DESCRIPTION
Mechanical CI hardening, no site changes:

- Every third-party `uses:` SHA-pinned with a version comment + weekly grouped dependabot
- `timeout-minutes` on all jobs (10 CI / 30 deploy)
- `terraform_version: 1.15.7` so the validate job stops floating on latest

Merge triggers the usual prod deploy -- content is untouched, so it redeploys what is already live.