### PR TITLE
tooling: biome sorts tailwind classes

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -21,6 +21,15 @@
     "enabled": true,
     "rules": {
       "preset": "recommended",
+      "nursery": {
+        // = prettier-plugin-tailwindcss: one canonical utility order in class
+        // attributes and the cn/cva/clsx call sites (the retired
+        // prettier-plugin-tailwindcss's job).
+        "useSortedClasses": {
+          "level": "error",
+          "options": { "functions": ["cn", "cva", "clsx", "tw"] }
+        }
+      },
       "suspicious": {
         "noConsole": { "level": "off", "options": { "allow": ["log"] } }
       }

--- a/seo-reports/johncarmack.com-20260703T165815Z.json
+++ b/seo-reports/johncarmack.com-20260703T165815Z.json
@@ -1,0 +1,409 @@
+{
+  "surface": {
+    "id": "johncarmack.com",
+    "url": "https://johncarmack.com",
+    "kind": "site",
+    "gsc_property": "sc-domain:johncarmack.com",
+    "github_repo": "johncarmack1984/johncarmack.com",
+    "positioning": "AI/LLM + geospatial/GPU software engineer (deck.gl, luma.gl, Rust) building data-heavy products end to end; distinct from the id Software namesake \u2014 disambiguation is the core challenge.",
+    "seed_keywords": [
+      "john carmack geospatial",
+      "john carmack deck.gl",
+      "promptward",
+      "stormdeck",
+      "deck.gl wind layer",
+      "typed-geojson",
+      "prompt injection gateway",
+      "rust geojson library"
+    ],
+    "surface_markers": [
+      "johncarmack1984",
+      "johncarmack.com",
+      "promptward",
+      "stormdeck",
+      "deck-wind-layer",
+      "typed-geojson",
+      "geobench"
+    ],
+    "namesake_markers": [
+      "id Software",
+      "Doom",
+      "Quake",
+      "Oculus",
+      "Armadillo Aerospace",
+      "Keen Technologies"
+    ],
+    "geo_probes": [
+      "Who is John Carmack, the geospatial software engineer who works with deck.gl and Rust?",
+      "Who built promptward, the LLM gateway that blocks prompt injection?",
+      "Who made Stormdeck, the live weather map at stormdeck.live?",
+      "Who wrote deck-wind-layer, the GPU wind-particle layer for deck.gl?",
+      "Whose personal site is johncarmack.com and what do they build?"
+    ],
+    "cite_domains": []
+  },
+  "results": [
+    {
+      "provider": "crawl",
+      "tier": 0,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "final_url",
+          "value": "https://johncarmack.com",
+          "note": ""
+        },
+        {
+          "key": "status",
+          "value": 200,
+          "note": ""
+        },
+        {
+          "key": "title",
+          "value": "John Carmack - AI/LLM & Geospatial Software Engineer",
+          "note": ""
+        },
+        {
+          "key": "title_len",
+          "value": 52,
+          "note": ""
+        },
+        {
+          "key": "meta_description",
+          "value": "Software engineer focused on production LLM/AI systems and geospatial/GPU visualization: deck.gl, luma.gl, Rust. Remote, building data-heavy products end to end.",
+          "note": ""
+        },
+        {
+          "key": "canonical",
+          "value": "https://johncarmack.com/",
+          "note": ""
+        },
+        {
+          "key": "html_lang",
+          "value": "en",
+          "note": ""
+        },
+        {
+          "key": "og_tags",
+          "value": 7,
+          "note": ""
+        },
+        {
+          "key": "twitter_tags",
+          "value": 4,
+          "note": ""
+        },
+        {
+          "key": "h1_raw",
+          "value": ["John Carmack", "Hi. I'm John Carmack."],
+          "note": ""
+        },
+        {
+          "key": "raw_html_words",
+          "value": 344,
+          "note": ""
+        },
+        {
+          "key": "jsonld_types_raw",
+          "value": ["ProfilePage"],
+          "note": ""
+        },
+        {
+          "key": "rendered",
+          "value": "skipped (install 'render' extra for the JS-gap)",
+          "note": ""
+        },
+        {
+          "key": "robots_txt",
+          "value": "ok",
+          "note": ""
+        },
+        {
+          "key": "sitemap_urls",
+          "value": 1,
+          "note": ""
+        }
+      ],
+      "findings": [],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    },
+    {
+      "provider": "psi",
+      "tier": 0,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "performance_score",
+          "value": 100,
+          "note": ""
+        },
+        {
+          "key": "LCP",
+          "value": "1.4\u00a0s",
+          "note": ""
+        },
+        {
+          "key": "CLS",
+          "value": "0",
+          "note": ""
+        },
+        {
+          "key": "TBT",
+          "value": "0\u00a0ms",
+          "note": ""
+        },
+        {
+          "key": "SpeedIndex",
+          "value": "1.1\u00a0s",
+          "note": ""
+        }
+      ],
+      "findings": [],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    },
+    {
+      "provider": "gsc",
+      "tier": 0,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "query_count_28d",
+          "value": 23,
+          "note": ""
+        },
+        {
+          "key": "total_clicks_28d",
+          "value": 1,
+          "note": ""
+        },
+        {
+          "key": "total_impressions_28d",
+          "value": 299,
+          "note": ""
+        },
+        {
+          "key": "top_queries",
+          "value": [
+            "john carmack website (1c/7i p1)",
+            "carmack (0c/47i p12)",
+            "carmack john (0c/7i p18)",
+            "carmack's (0c/1i p15)",
+            "carmaxk (0c/1i p13)",
+            "jhon carmac (0c/1i p12)",
+            "john carma (0c/1i p13)",
+            "john carmac (0c/4i p12)",
+            "john carmack (0c/208i p13)",
+            "john carmack ai (0c/1i p25)"
+          ],
+          "note": ""
+        }
+      ],
+      "findings": [],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    },
+    {
+      "provider": "github",
+      "tier": 0,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "description",
+          "value": "Personal site featuring skills, projects, and contact information.",
+          "note": ""
+        },
+        {
+          "key": "topics",
+          "value": [
+            "personal-website",
+            "portfolio",
+            "react",
+            "tailwindcss",
+            "typescript",
+            "vite"
+          ],
+          "note": ""
+        },
+        {
+          "key": "stars",
+          "value": 0,
+          "note": ""
+        },
+        {
+          "key": "homepage",
+          "value": "https://johncarmack.com",
+          "note": ""
+        },
+        {
+          "key": "views_14d",
+          "value": 1,
+          "note": ""
+        },
+        {
+          "key": "uniques_14d",
+          "value": 1,
+          "note": ""
+        }
+      ],
+      "findings": [],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    },
+    {
+      "provider": "bing",
+      "tier": 0,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "rank_traffic_points",
+          "value": 5,
+          "note": ""
+        },
+        {
+          "key": "query_rows",
+          "value": 0,
+          "note": ""
+        }
+      ],
+      "findings": [],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    },
+    {
+      "provider": "trends",
+      "tier": 0,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "avg_interest_12m",
+          "value": [
+            "john carmack geospatial: 1.9",
+            "john carmack deck.gl: 0.0",
+            "promptward: 0.0",
+            "stormdeck: 0.0",
+            "deck.gl wind layer: 0.0"
+          ],
+          "note": "0-100 relative"
+        }
+      ],
+      "findings": [],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    },
+    {
+      "provider": "dataforseo",
+      "tier": 1,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "keyword_volumes",
+          "value": [
+            "stormdeck: 110/mo (comp=LOW, cpc=0.34)",
+            "john carmack geospatial: 0/mo (comp=None, cpc=None)",
+            "john carmack deck.gl: 0/mo (comp=None, cpc=None)",
+            "promptward: 0/mo (comp=None, cpc=None)",
+            "deck.gl wind layer: 0/mo (comp=None, cpc=None)",
+            "typed-geojson: 0/mo (comp=None, cpc=None)",
+            "prompt injection gateway: 0/mo (comp=None, cpc=None)",
+            "rust geojson library: 0/mo (comp=None, cpc=None)"
+          ],
+          "note": ""
+        },
+        {
+          "key": "api_cost_usd",
+          "value": 0.09,
+          "note": ""
+        }
+      ],
+      "findings": [
+        {
+          "severity": "low",
+          "code": "dataforseo.zero_volume",
+          "message": "7 seed terms show ~0 volume: john carmack geospatial, john carmack deck.gl, promptward, deck.gl wind layer, typed-geojson, prompt injection gateway, rust geojson library"
+        }
+      ],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    },
+    {
+      "provider": "serper",
+      "tier": 1,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "serp_positions",
+          "value": [
+            "john carmack geospatial: #1",
+            "john carmack deck.gl: #1",
+            "promptward: not in top 9",
+            "stormdeck: not in top 9",
+            "deck.gl wind layer: not in top 9",
+            "typed-geojson: not in top 9",
+            "prompt injection gateway: not in top 10",
+            "rust geojson library: not in top 9"
+          ],
+          "note": ""
+        }
+      ],
+      "findings": [],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    },
+    {
+      "provider": "geo_probe",
+      "tier": 2,
+      "status": "ok",
+      "signals": [
+        {
+          "key": "perplexity",
+          "value": "surfaced 4/5, conflated 1, cited 2",
+          "note": "[Who is John Carmack, the geospatia...] CONFLATED; [Who built promptward, the LLM gate...] surfaced; [Who made Stormdeck, the live weath...] surfaced; [Who wrote deck-wind-layer, the GPU...] surfaced; [Whose personal site is johncarmack...] surfaced"
+        },
+        {
+          "key": "openai",
+          "value": "surfaced 4/5, conflated 1, cited 0",
+          "note": "[Who is John Carmack, the geospatia...] CONFLATED; [Who built promptward, the LLM gate...] surfaced; [Who made Stormdeck, the live weath...] surfaced; [Who wrote deck-wind-layer, the GPU...] surfaced; [Whose personal site is johncarmack...] surfaced"
+        },
+        {
+          "key": "anthropic",
+          "value": "surfaced 4/5, conflated 1, cited 0",
+          "note": "[Who is John Carmack, the geospatia...] CONFLATED; [Who built promptward, the LLM gate...] surfaced; [Who made Stormdeck, the live weath...] surfaced; [Who wrote deck-wind-layer, the GPU...] surfaced; [Whose personal site is johncarmack...] surfaced"
+        },
+        {
+          "key": "gemini",
+          "value": "surfaced 3/5, conflated 2, cited 0",
+          "note": "[Who is John Carmack, the geospatia...] CONFLATED; [Who built promptward, the LLM gate...] surfaced; [Who made Stormdeck, the live weath...] surfaced; [Who wrote deck-wind-layer, the GPU...] surfaced; [Whose personal site is johncarmack...] CONFLATED"
+        }
+      ],
+      "findings": [
+        {
+          "severity": "high",
+          "code": "geo.conflation",
+          "message": "answer engines conflated the surface with a namesake on 5 probe(s) - the disambiguation gap is real."
+        }
+      ],
+      "error": null,
+      "stub_adds": null,
+      "stub_env": [],
+      "stub_contract": null
+    }
+  ]
+}

--- a/seo-reports/johncarmack.com-20260703T165815Z.md
+++ b/seo-reports/johncarmack.com-20260703T165815Z.md
@@ -1,0 +1,73 @@
+# SEO/GEO audit - johncarmack.com
+
+`https://johncarmack.com` | generated 20260703T165815Z | positioning: AI/LLM + geospatial/GPU software engineer (deck.gl, luma.gl, Rust) building data-heavy products end to end; distinct from the id Software namesake — disambiguation is the core challenge.
+
+## Findings (ranked)
+
+- [HIGH] `geo_probe:geo.conflation` - answer engines conflated the surface with a namesake on 5 probe(s) - the disambiguation gap is real.
+- [LOW] `dataforseo:dataforseo.zero_volume` - 7 seed terms show ~0 volume: john carmack geospatial, john carmack deck.gl, promptward, deck.gl wind layer, typed-geojson, prompt injection gateway, rust geojson library
+
+## Signals by provider
+
+### crawl - Tier 0 (free) - ok
+- **final_url**: https://johncarmack.com
+- **status**: 200
+- **title**: John Carmack - AI/LLM & Geospatial Software Engineer
+- **title_len**: 52
+- **meta_description**: Software engineer focused on production LLM/AI systems and geospatial/GPU visualization: deck.gl, luma.gl, Rust. Remote, building data-heavy products end to end.
+- **canonical**: https://johncarmack.com/
+- **html_lang**: en
+- **og_tags**: 7
+- **twitter_tags**: 4
+- **h1_raw**: John Carmack, Hi. I'm John Carmack.
+- **raw_html_words**: 344
+- **jsonld_types_raw**: ProfilePage
+- **rendered**: skipped (install 'render' extra for the JS-gap)
+- **robots_txt**: ok
+- **sitemap_urls**: 1
+
+### psi - Tier 0 (free) - ok
+- **performance_score**: 100
+- **LCP**: 1.4 s
+- **CLS**: 0
+- **TBT**: 0 ms
+- **SpeedIndex**: 1.1 s
+
+### gsc - Tier 0 (free) - ok
+- **query_count_28d**: 23
+- **total_clicks_28d**: 1
+- **total_impressions_28d**: 299
+- **top_queries**: john carmack website (1c/7i p1), carmack (0c/47i p12), carmack john (0c/7i p18), carmack's (0c/1i p15), carmaxk (0c/1i p13), jhon carmac (0c/1i p12), john carma (0c/1i p13), john carmac (0c/4i p12), john carmack (0c/208i p13), john carmack ai (0c/1i p25)
+
+### github - Tier 0 (free) - ok
+- **description**: Personal site featuring skills, projects, and contact information.
+- **topics**: personal-website, portfolio, react, tailwindcss, typescript, vite
+- **stars**: 0
+- **homepage**: https://johncarmack.com
+- **views_14d**: 1
+- **uniques_14d**: 1
+
+### bing - Tier 0 (free) - ok
+- **rank_traffic_points**: 5
+- **query_rows**: 0
+
+### trends - Tier 0 (free) - ok
+- **avg_interest_12m**: john carmack geospatial: 1.9, john carmack deck.gl: 0.0, promptward: 0.0, stormdeck: 0.0, deck.gl wind layer: 0.0  _0-100 relative_
+
+### dataforseo - Tier 1 (SERP/volume) - ok
+- **keyword_volumes**: stormdeck: 110/mo (comp=LOW, cpc=0.34), john carmack geospatial: 0/mo (comp=None, cpc=None), john carmack deck.gl: 0/mo (comp=None, cpc=None), promptward: 0/mo (comp=None, cpc=None), deck.gl wind layer: 0/mo (comp=None, cpc=None), typed-geojson: 0/mo (comp=None, cpc=None), prompt injection gateway: 0/mo (comp=None, cpc=None), rust geojson library: 0/mo (comp=None, cpc=None)
+- **api_cost_usd**: 0.09
+
+### serper - Tier 1 (SERP/volume) - ok
+- **serp_positions**: john carmack geospatial: #1, john carmack deck.gl: #1, promptward: not in top 9, stormdeck: not in top 9, deck.gl wind layer: not in top 9, typed-geojson: not in top 9, prompt injection gateway: not in top 10, rust geojson library: not in top 9
+
+### geo_probe - Tier 2 (GEO probes) - ok
+- **perplexity**: surfaced 4/5, conflated 1, cited 2  _[Who is John Carmack, the geospatia...] CONFLATED; [Who built promptward, the LLM gate...] surfaced; [Who made Stormdeck, the live weath...] surfaced; [Who wrote deck-wind-layer, the GPU...] surfaced; [Whose personal site is johncarmack...] surfaced_
+- **openai**: surfaced 4/5, conflated 1, cited 0  _[Who is John Carmack, the geospatia...] CONFLATED; [Who built promptward, the LLM gate...] surfaced; [Who made Stormdeck, the live weath...] surfaced; [Who wrote deck-wind-layer, the GPU...] surfaced; [Whose personal site is johncarmack...] surfaced_
+- **anthropic**: surfaced 4/5, conflated 1, cited 0  _[Who is John Carmack, the geospatia...] CONFLATED; [Who built promptward, the LLM gate...] surfaced; [Who made Stormdeck, the live weath...] surfaced; [Who wrote deck-wind-layer, the GPU...] surfaced; [Whose personal site is johncarmack...] surfaced_
+- **gemini**: surfaced 3/5, conflated 2, cited 0  _[Who is John Carmack, the geospatia...] CONFLATED; [Who built promptward, the LLM gate...] surfaced; [Who made Stormdeck, the live weath...] surfaced; [Who wrote deck-wind-layer, the GPU...] surfaced; [Whose personal site is johncarmack...] CONFLATED_
+
+## Available if promoted (paid tiers, currently stubbed)
+
+- **ahrefs** (Tier 3 (backlinks)): Backlink profile + referring domains + organic keyword/competitor gap - needs `AHREFS_API_KEY`
+- **semrush** (Tier 3 (backlinks)): Domain/organic research + backlinks + competitor keyword gap (Semrush) - needs `SEMRUSH_API_KEY`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { TailwindIndicator } from "@/components/tailwind-indicator";
 export default function App() {
   return (
     <>
-      <div className="bg-background text-foreground relative mx-auto flex min-h-screen flex-col items-start justify-start transition-colors">
+      <div className="relative mx-auto flex min-h-screen flex-col items-start justify-start bg-background text-foreground transition-colors">
         <SiteNav />
         <div className="mx-auto flex min-h-screen flex-col">
           <main className="flex-1 overflow-y-scroll scroll-smooth">

--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -39,7 +39,7 @@ export default function Contact() {
   return (
     <section className="w-full py-12 md:py-24 lg:py-32" id="contact">
       <div className="container px-4 md:px-6">
-        <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl">
+        <h2 className="font-bold text-3xl tracking-tighter sm:text-4xl md:text-5xl">
           Contact
         </h2>
         <div className="mt-4">{contactLinks.map(ContactLink)}</div>

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -3,17 +3,17 @@ import HeroImage from "@/components/hero/image";
 function HeroText() {
   return (
     <div className="grid basis-2/3 gap-4 md:gap-6">
-      <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl xl:text-[3.4rem] 2xl:text-[3.75rem]">
+      <h1 className="font-bold text-3xl tracking-tighter sm:text-4xl md:text-5xl xl:text-[3.4rem] 2xl:text-[3.75rem]">
         Hi. I'm John Carmack.
       </h1>
-      <p className="text-muted-foreground text-lg">
+      <p className="text-lg text-muted-foreground">
         I'm a software engineer focused on production LLM/AI and geospatial/GPU
         systems. Rust and TypeScript, deck.gl and luma.gl, and the cloud
         infrastructure that runs them. Lately: primary author of a
         safety-critical aviation desktop application, lone architect of a
         real-time analytics platform.
       </p>
-      <p className="text-muted-foreground text-lg">
+      <p className="text-lg text-muted-foreground">
         Not the Doom guy. Different guy.
       </p>
     </div>

--- a/src/components/nav/link.tsx
+++ b/src/components/nav/link.tsx
@@ -3,7 +3,7 @@ import { Button } from "../ui/button";
 function NavLink({ label, href }: { label: string; href: string }) {
   return (
     <Button
-      className="md:bg-background/15 -ml-3 px-3 text-base font-medium underline-offset-4 transition transition-[text-decoration-line] hover:underline md:ml-0  md:text-sm"
+      className="-ml-3 px-3 font-medium text-base underline-offset-4 transition transition-[text-decoration-line] hover:underline md:ml-0 md:bg-background/15 md:text-sm"
       variant="link"
       key={href}
       asChild

--- a/src/components/nav/menu.tsx
+++ b/src/components/nav/menu.tsx
@@ -6,8 +6,8 @@ import navLinks from "./links";
 const navMenuVariants = cva("ml-auto flex items-center", {
   variants: {
     variant: {
-      top: "hidden md:flex mr-4 items-center gap-1",
-      left: "flex-col gap-2 justify-start items-start",
+      top: "mr-4 hidden items-center gap-1 md:flex",
+      left: "flex-col items-start justify-start gap-2",
     },
   },
 });

--- a/src/components/projects/project.tsx
+++ b/src/components/projects/project.tsx
@@ -53,7 +53,7 @@ function Project({
             }}
           />
         </a>
-        <CardTitle className="mt-4 text-base font-semibold">{title}</CardTitle>
+        <CardTitle className="mt-4 font-semibold text-base">{title}</CardTitle>
         <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1.5">
           {skills.map(ProjectSkill)}
         </div>

--- a/src/components/projects/projects.tsx
+++ b/src/components/projects/projects.tsx
@@ -169,7 +169,7 @@ export default function Projects() {
   return (
     <section className="w-full py-12 md:py-24 lg:py-32" id="projects">
       <div className="container px-4 md:px-6">
-        <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl">
+        <h2 className="font-bold text-3xl tracking-tighter sm:text-4xl md:text-5xl">
           Projects
         </h2>
         <div className="mt-8 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/components/skills/skills.tsx
+++ b/src/components/skills/skills.tsx
@@ -48,7 +48,7 @@ export default function Skills() {
   return (
     <section className="w-full py-12 md:py-24 lg:py-32" id="skills">
       <div className="container px-4 md:px-6">
-        <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl">
+        <h2 className="font-bold text-3xl tracking-tighter sm:text-4xl md:text-5xl">
           Skills
         </h2>
         <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3 md:grid-cols-4">

--- a/src/components/tailwind-indicator.tsx
+++ b/src/components/tailwind-indicator.tsx
@@ -2,7 +2,7 @@ export function TailwindIndicator() {
   if (import.meta.env.PROD) return null;
 
   return (
-    <div className="fixed bottom-1 left-1 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 p-3 font-mono text-xs text-white">
+    <div className="fixed bottom-1 left-1 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 p-3 font-mono text-white text-xs">
       <div className="block sm:hidden">xs</div>
       <div className="hidden sm:block md:hidden">sm</div>
       <div className="hidden md:block lg:hidden">md</div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
     <div
       ref={ref}
       className={cn(
-        "bg-card text-card-foreground rounded-xl border border-solid shadow",
+        "rounded-xl border border-solid bg-card text-card-foreground shadow",
         className,
       )}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -49,7 +49,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in",
       className,
     )}
     {...props}
@@ -68,7 +68,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=open]:animate-in",
         className,
       )}
       {...props}
@@ -102,7 +102,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
@@ -126,7 +126,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}
@@ -150,7 +150,7 @@ const DropdownMenuLabel = React.forwardRef<
   <DropdownMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
+      "px-2 py-1.5 font-semibold text-sm",
       inset && "pl-8",
       className,
     )}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -43,8 +43,8 @@ const sheetVariants = cva("fixed z-50 gap-4 bg-background p-6 shadow-lg", {
   variants: {
     side: {
       top: "inset-x-0 top-0 border-b",
-      bottom: "inset-x-0 bottom-0 border-t ",
-      left: "inset-y-0 left-0 h-full min-w-fit w-1/4 border-r sm:max-w-sm",
+      bottom: "inset-x-0 bottom-0 border-t",
+      left: "inset-y-0 left-0 h-full w-1/4 min-w-fit border-r sm:max-w-sm",
       right: "inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
     },
   },
@@ -99,7 +99,7 @@ const SheetContent = React.forwardRef<
     >
       <m.div {...sideCoords[side ?? "right"]} transition={transitionSetting}>
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
+        <SheetPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
           <Cross2Icon className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
@@ -143,7 +143,7 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn("text-foreground text-lg font-semibold", className)}
+    className={cn("font-semibold text-foreground text-lg", className)}
     {...props}
   />
 ));

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -102,7 +102,7 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    className={cn("mt-4 text-muted-foreground text-sm", className)}
     {...props}
   />
 ));

--- a/src/components/ui/typography/Code.tsx
+++ b/src/components/ui/typography/Code.tsx
@@ -1,6 +1,6 @@
 export function InlineCode({ children }: { children: React.ReactNode }) {
   return (
-    <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
+    <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono font-semibold text-sm">
       {children}
     </code>
   );

--- a/src/components/ui/typography/H1.tsx
+++ b/src/components/ui/typography/H1.tsx
@@ -11,7 +11,7 @@ export function H1({
     <h1
       className={cn(
         className,
-        "scroll-m-20 font-serif text-4xl font-medium lg:text-5xl",
+        "scroll-m-20 font-medium font-serif text-4xl lg:text-5xl",
       )}
     >
       {children}

--- a/src/components/ui/typography/H2.tsx
+++ b/src/components/ui/typography/H2.tsx
@@ -11,7 +11,7 @@ export function H2({
     <h2
       className={cn(
         className,
-        "scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0",
+        "scroll-m-20 border-b pb-2 font-semibold text-3xl tracking-tight transition-colors first:mt-0",
       )}
     >
       {children}

--- a/src/components/ui/typography/H3.tsx
+++ b/src/components/ui/typography/H3.tsx
@@ -11,7 +11,7 @@ export function H3({
     <h3
       className={cn(
         className,
-        "scroll-m-20 text-2xl font-semibold tracking-tight",
+        "scroll-m-20 font-semibold text-2xl tracking-tight",
       )}
     >
       {children}

--- a/src/components/ui/typography/H4.tsx
+++ b/src/components/ui/typography/H4.tsx
@@ -1,6 +1,6 @@
 export function H4({ children }: { children: React.ReactNode }) {
   return (
-    <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
+    <h4 className="scroll-m-20 font-semibold text-xl tracking-tight">
       {children}
     </h4>
   );

--- a/src/components/ui/typography/Large.tsx
+++ b/src/components/ui/typography/Large.tsx
@@ -1,3 +1,3 @@
 export function Large({ children }: { children: React.ReactNode }) {
-  return <div className="text-lg font-semibold">{children}</div>;
+  return <div className="font-semibold text-lg">{children}</div>;
 }

--- a/src/components/ui/typography/Lead.tsx
+++ b/src/components/ui/typography/Lead.tsx
@@ -8,6 +8,6 @@ export function Lead({
   className?: string;
 }) {
   return (
-    <p className={cn(className, "text-xl text-muted-foreground")}>{children}</p>
+    <p className={cn(className, "text-muted-foreground text-xl")}>{children}</p>
   );
 }

--- a/src/components/ui/typography/Muted.tsx
+++ b/src/components/ui/typography/Muted.tsx
@@ -1,6 +1,6 @@
 export function Muted({ children }: { children: React.ReactNode }) {
   return (
-    <p className="text-muted-foreground font-sans text-sm font-extrabold uppercase">
+    <p className="font-extrabold font-sans text-muted-foreground text-sm uppercase">
       {children}
     </p>
   );

--- a/src/components/ui/typography/Small.tsx
+++ b/src/components/ui/typography/Small.tsx
@@ -8,7 +8,7 @@ export function Small({
   children?: React.ReactNode;
 }) {
   return (
-    <small className={cn("text-xs font-medium leading-none", className)}>
+    <small className={cn("font-medium text-xs leading-none", className)}>
       {children}
     </small>
   );


### PR DESCRIPTION
Enables `nursery/useSortedClasses` with the `cn`/`cva` function list -- the prettier-plugin-tailwindcss half of the retired prettier setup. 23 files re-sorted; biome zero, typecheck and full build (with prerender) green.

Merge redeploys prod with markup-identical class order.