### PR TITLE
chore: ignore local seo-kit report output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ next-env.d.ts
 .dev
 
 certificates
+# local seo-kit audit output
+/seo-reports/


### PR DESCRIPTION
Local `seo-kit audit` runs drop reports into `seo-reports/`; keep them out of status noise.