### PR TITLE
site: group projects and skills by focus area

### DIFF
--- a/src/components/projects/projects.tsx
+++ b/src/components/projects/projects.tsx
@@ -67,6 +67,17 @@ const P = {
   library: { Icon: CodeIcon, name: "Library" },
 } satisfies Record<string, Tool>;
 
+// Projects are grouped by focus area so the specialties read at a glance. This
+// order sets which section leads; change a project's `group` to move its card.
+const groupOrder = [
+  "LLM / AI",
+  "Geospatial & GPU",
+  "Apps",
+  "Infrastructure & tooling",
+] as const;
+
+type Group = (typeof groupOrder)[number];
+
 const projects = [
   // Sheaf: prepped for launch. Delete `hidden: true` to flip it live.
   {
@@ -77,16 +88,8 @@ const projects = [
     href: "https://github.com/johncarmack1984/message-to-pdf",
     platforms: [P.macos],
     skills: [T.rust, T.tauri, T.ts],
+    group: "Apps",
     hidden: true,
-  },
-  {
-    title: "seo-kit",
-    description:
-      "Real-data SEO + GEO audits: does Google rank you, do LLMs cite you.",
-    image: seoKit,
-    href: "https://seo-kit.johncarmack.com",
-    platforms: [P.cli],
-    skills: [T.python, T.aws, T.terraform],
   },
   {
     title: "promptward",
@@ -96,6 +99,17 @@ const projects = [
     href: "https://github.com/johncarmack1984/promptward",
     platforms: [P.web],
     skills: [T.rust, T.ts, T.react, T.vite],
+    group: "LLM / AI",
+  },
+  {
+    title: "seo-kit",
+    description:
+      "Real-data SEO + GEO audits: does Google rank you, do LLMs cite you.",
+    image: seoKit,
+    href: "https://seo-kit.johncarmack.com",
+    platforms: [P.cli],
+    skills: [T.python, T.aws, T.terraform],
+    group: "LLM / AI",
   },
   {
     title: "Stormdeck",
@@ -117,6 +131,7 @@ const projects = [
       T.aws,
       T.cdk,
     ],
+    group: "Geospatial & GPU",
   },
   {
     title: "deck-wind-layer",
@@ -125,6 +140,7 @@ const projects = [
     href: "https://github.com/johncarmack1984/deck-wind-layer",
     platforms: [P.web],
     skills: [T.ts, T.deckgl, T.webgl, T.lumagl, T.vite],
+    group: "Geospatial & GPU",
   },
   {
     title: "glslint",
@@ -134,6 +150,7 @@ const projects = [
     href: "https://github.com/johncarmack1984/glslint",
     platforms: [P.cli, P.library],
     skills: [T.rust, T.ts, T.deckgl, T.lumagl],
+    group: "Geospatial & GPU",
   },
   {
     title: "geo-desktop-bench",
@@ -142,6 +159,16 @@ const projects = [
     href: "https://geobench.johncarmack.com",
     platforms: [P.web],
     skills: [T.rust, T.ts, T.deckgl, T.maplibre, T.webgl, T.lumagl, T.tauri],
+    group: "Geospatial & GPU",
+  },
+  {
+    title: "typed-geojson",
+    description: "Strongly-typed GeoJSON for Rust.",
+    image: typedGeojson,
+    href: "https://github.com/johncarmack1984/typed-geojson",
+    platforms: [P.library],
+    skills: [T.rust, T.ts],
+    group: "Geospatial & GPU",
   },
   {
     title: "Lux",
@@ -152,6 +179,7 @@ const projects = [
     appStore: "https://apps.apple.com/us/app/lux-for-dmx/id6788795353",
     platforms: [P.macos, P.ios],
     skills: [T.rust, T.axum, T.ts, T.react, T.tailwind, T.tauri, T.terraform],
+    group: "Apps",
   },
   {
     title: "vegify.app",
@@ -162,22 +190,7 @@ const projects = [
     appStore: "https://apps.apple.com/us/app/vegify-app/id6787673614",
     platforms: [P.web, P.ios],
     skills: [T.rust, T.axum, T.ts, T.react, T.tailwind, T.vite, T.tauri],
-  },
-  {
-    title: "typed-geojson",
-    description: "Strongly-typed GeoJSON for Rust.",
-    image: typedGeojson,
-    href: "https://github.com/johncarmack1984/typed-geojson",
-    platforms: [P.library],
-    skills: [T.rust, T.ts],
-  },
-  {
-    title: "tauri-typed-ipc",
-    description: "Type-safe Tauri IPC from a single Rust trait.",
-    image: tauriTypedIpc,
-    href: "https://github.com/johncarmack1984/tauri-typed-ipc",
-    platforms: [P.library],
-    skills: [T.rust, T.tauri, T.ts, T.vite],
+    group: "Apps",
   },
   {
     title: "Manifest",
@@ -186,6 +199,7 @@ const projects = [
     href: "https://github.com/johncarmack1984/manifest",
     platforms: [P.web],
     skills: [T.rust, T.axum, T.ts, T.react, T.tailwind, T.vite, T.aws, T.cdk],
+    group: "Infrastructure & tooling",
   },
   {
     title: "accept-payments",
@@ -194,6 +208,16 @@ const projects = [
     href: "https://github.com/johncarmack1984/accept-payments",
     platforms: [P.web],
     skills: [T.rust, T.axum, T.stripe, T.ts, T.react, T.aws],
+    group: "Infrastructure & tooling",
+  },
+  {
+    title: "tauri-typed-ipc",
+    description: "Type-safe Tauri IPC from a single Rust trait.",
+    image: tauriTypedIpc,
+    href: "https://github.com/johncarmack1984/tauri-typed-ipc",
+    platforms: [P.library],
+    skills: [T.rust, T.tauri, T.ts, T.vite],
+    group: "Infrastructure & tooling",
   },
   {
     title: "Deep Freeze",
@@ -202,18 +226,43 @@ const projects = [
     href: "https://github.com/johncarmack1984/deep-freeze",
     platforms: [P.cli],
     skills: [T.rust, T.aws, T.terraform],
+    group: "Infrastructure & tooling",
   },
-];
+] satisfies Array<{
+  title: string;
+  description: string;
+  image: string;
+  href: string;
+  appStore?: string;
+  platforms: Tool[];
+  skills: Tool[];
+  group: Group;
+  hidden?: boolean;
+}>;
 
 export default function Projects() {
+  const visible = projects.filter((project) => !project.hidden);
   return (
     <section className="w-full py-12 md:py-24 lg:py-32" id="projects">
       <div className="container px-4 md:px-6">
         <h2 className="font-bold text-3xl tracking-tighter sm:text-4xl md:text-5xl">
           Projects
         </h2>
-        <div className="mt-8 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-          {projects.filter((project) => !project.hidden).map(Project)}
+        <div className="mt-8 flex flex-col gap-12">
+          {groupOrder.map((group) => {
+            const items = visible.filter((project) => project.group === group);
+            if (items.length === 0) return null;
+            return (
+              <div key={group}>
+                <h3 className="font-semibold text-muted-foreground text-sm uppercase tracking-wider">
+                  {group}
+                </h3>
+                <div className="mt-6 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+                  {items.map(Project)}
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/src/components/skills/skill.tsx
+++ b/src/components/skills/skill.tsx
@@ -1,20 +1,6 @@
 import type { JSX } from "react";
 import type { IconProps } from "@radix-ui/react-icons/dist/types";
 
-import { Card } from "@/components/ui/card";
-
-interface SkillIconProps extends IconProps {}
-
-type SkillIcon = (props: SkillIconProps) => JSX.Element;
-
-function Skill({ Icon, name }: { Icon: SkillIcon; name: string }) {
-  return (
-    <Card key={name} className="flex items-center gap-4 rounded-md p-4">
-      <Icon className="inline size-12 fill-current" />
-      <h3 className="font-semibold">{name}</h3>
-    </Card>
-  );
-}
+type SkillIcon = (props: IconProps) => JSX.Element;
 
 export type { SkillIcon };
-export default Skill;

--- a/src/components/skills/skills.tsx
+++ b/src/components/skills/skills.tsx
@@ -19,30 +19,68 @@ import TypeScriptIcon from "@/components/ui/icons/typescript";
 import ViteIcon from "@/components/ui/icons/vite";
 import WebGlIcon from "@/components/ui/icons/webgl";
 
-import Skill from "./skill";
+import type { SkillIcon } from "./skill";
 
-const skills = [
-  { Icon: RustIcon, name: "Rust" },
-  { Icon: TypeScriptIcon, name: "TypeScript" },
-  { Icon: JavaScriptIcon, name: "JavaScript" },
-  { Icon: ReactIcon, name: "React" },
-  { Icon: TailwindIcon, name: "Tailwind CSS" },
-  { Icon: NextJsIcon, name: "Next.js" },
-  { Icon: ViteIcon, name: "Vite" },
-  { Icon: NodeJsIcon, name: "Node.js" },
-  { Icon: TauriIcon, name: "Tauri" },
-  { Icon: MapLibreIcon, name: "MapLibre" },
-  { Icon: DeckGlIcon, name: "deck.gl" },
-  { Icon: WebGlIcon, name: "WebGL" },
-  { Icon: D3Icon, name: "D3.js" },
-  { Icon: PythonIcon, name: "Python" },
-  { Icon: PostgreSqlIcon, name: "PostgreSQL" },
-  { Icon: SnowflakeIcon, name: "Snowflake" },
-  { Icon: AwsIcon, name: "AWS" },
-  { Icon: TerraformIcon, name: "Terraform" },
-  { Icon: KubernetesIcon, name: "Kubernetes" },
-  { Icon: GitHubActionsIcon, name: "GitHub Actions" },
+type Skill = { Icon: SkillIcon; name: string };
+
+// Grouped so the specialties read at a glance: languages and the GPU/geospatial
+// stack lead, then the supporting frontend, data, and cloud tooling.
+const skillGroups: { label: string; skills: Skill[] }[] = [
+  {
+    label: "Languages",
+    skills: [
+      { Icon: RustIcon, name: "Rust" },
+      { Icon: TypeScriptIcon, name: "TypeScript" },
+      { Icon: JavaScriptIcon, name: "JavaScript" },
+      { Icon: PythonIcon, name: "Python" },
+    ],
+  },
+  {
+    label: "GPU & geospatial",
+    skills: [
+      { Icon: DeckGlIcon, name: "deck.gl" },
+      { Icon: WebGlIcon, name: "WebGL" },
+      { Icon: MapLibreIcon, name: "MapLibre" },
+      { Icon: D3Icon, name: "D3.js" },
+    ],
+  },
+  {
+    label: "Frontend & apps",
+    skills: [
+      { Icon: ReactIcon, name: "React" },
+      { Icon: NextJsIcon, name: "Next.js" },
+      { Icon: ViteIcon, name: "Vite" },
+      { Icon: TailwindIcon, name: "Tailwind CSS" },
+      { Icon: NodeJsIcon, name: "Node.js" },
+      { Icon: TauriIcon, name: "Tauri" },
+    ],
+  },
+  {
+    label: "Data",
+    skills: [
+      { Icon: PostgreSqlIcon, name: "PostgreSQL" },
+      { Icon: SnowflakeIcon, name: "Snowflake" },
+    ],
+  },
+  {
+    label: "Cloud & DevOps",
+    skills: [
+      { Icon: AwsIcon, name: "AWS" },
+      { Icon: TerraformIcon, name: "Terraform" },
+      { Icon: KubernetesIcon, name: "Kubernetes" },
+      { Icon: GitHubActionsIcon, name: "GitHub Actions" },
+    ],
+  },
 ];
+
+function SkillItem({ Icon, name }: Skill) {
+  return (
+    <span className="inline-flex items-center gap-2 text-sm">
+      <Icon className="size-5 fill-current" />
+      {name}
+    </span>
+  );
+}
 
 export default function Skills() {
   return (
@@ -51,8 +89,22 @@ export default function Skills() {
         <h2 className="font-bold text-3xl tracking-tighter sm:text-4xl md:text-5xl">
           Skills
         </h2>
-        <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3 md:grid-cols-4">
-          {skills.map(Skill)}
+        <div className="mt-8 flex flex-col divide-y divide-border">
+          {skillGroups.map((group) => (
+            <div
+              key={group.label}
+              className="flex flex-col gap-2 py-5 first:pt-0 sm:flex-row sm:gap-8"
+            >
+              <h3 className="shrink-0 font-semibold text-muted-foreground text-sm uppercase tracking-wider sm:w-44 sm:pt-0.5">
+                {group.label}
+              </h3>
+              <div className="flex flex-wrap gap-x-6 gap-y-3">
+                {group.skills.map((skill) => (
+                  <SkillItem key={skill.name} {...skill} />
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Group projects and skills by focus area

Follow-up to the declutter pass. The homepage read as "does a bit of everything" instead of showing a specialty. This organizes both dense sections around focus areas so the specialization the hero claims (production LLM/AI and geospatial/GPU, in Rust and TypeScript) actually reads on the page. Direction picked from the two options you chose: keep everything, group it.

### What changed

- **Projects grouped by focus area.** One undifferentiated grid of 13 cards becomes four labeled groups: **LLM / AI**, **Geospatial & GPU**, **Apps**, and **Infrastructure & tooling**. Every card is kept; each just carries a `group`. The two headline areas lead, matching the hero.
- **Skills went from 20 equal tiles to five compact labeled rows:** Languages, GPU & geospatial, Frontend & apps, Data, Cloud & DevOps. Every skill is kept, but the category names do the work of signaling the specialty and the section carries far less visual weight.
- Small cleanup: `skill.tsx` is now just the shared `SkillIcon` type; the big tile component it used to export is gone.

`biome check`, `tsc --noEmit`, and the production build all pass. Open source, hero, and contact are untouched.

### Skills: before / after

**Before** (20 icon tiles)

![Skills before](https://raw.githubusercontent.com/johncarmack1984/johncarmack.com/pr-assets/focus-projects-skills/before-skills.png)

**After** (five labeled rows)

![Skills after](https://raw.githubusercontent.com/johncarmack1984/johncarmack.com/pr-assets/focus-projects-skills/after-skills.png)

### Projects: before / after

**Before** (one grid)

![Projects before](https://raw.githubusercontent.com/johncarmack1984/johncarmack.com/pr-assets/focus-projects-skills/before-projects.png)

**After** (grouped by focus area)

![Projects after](https://raw.githubusercontent.com/johncarmack1984/johncarmack.com/pr-assets/focus-projects-skills/after-projects.png)

### Full page: before / after

<table>
<tr><td align="center"><b>Before</b></td><td align="center"><b>After</b></td></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/johncarmack1984/johncarmack.com/pr-assets/focus-projects-skills/before-home.png" width="430"></td>
<td><img src="https://raw.githubusercontent.com/johncarmack1984/johncarmack.com/pr-assets/focus-projects-skills/after-home.png" width="430"></td>
</tr>
</table>

### One honest tradeoff

Grouping keeps all 13 project cards, so the page is a bit taller than before (the four subheadings add height). It reads far more focused, but it is not shorter. If you want it actually shorter too, the easy follow-ups are: curate the projects down to a featured set, or tighten the big section spacing. Say the word and I will do either.

Two orderings are one-line swaps if you want them: which focus area leads (LLM/AI vs Geospatial & GPU), and the group labels themselves.

---

The site auto-deploys on merge, so I have left this open for your call. Nothing here is merged.

<sub>Screenshots are hosted on the `pr-assets/focus-projects-skills` branch, kept out of this diff and off `main`; delete that branch once reviewed.</sub>
