### PR TITLE
ci: check for unused dependencies with knip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: bun run lint
       - name: Typecheck
         run: bun run typecheck
+      - name: Unused dependencies (knip)
+        run: bunx knip --dependencies
       - name: Build
         run: bun run build
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "format": "biome format --write .",
-    "check": "biome check . && tsc --noEmit && bun run build"
+    "check": "biome check . && bunx knip --dependencies && tsc --noEmit && bun run build"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.18",


### PR DESCRIPTION
Adds a knip dependencies check to CI and the local check script. The dependency tree is already clean; this keeps it that way.