### PR TITLE
site: fix meta description length, complete OG/Twitter tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>John Carmack - AI/LLM & Geospatial Software Engineer</title>
     <meta
       name="description"
-      content="Software engineer focused on production LLM/AI systems and geospatial/GPU visualization: deck.gl, luma.gl, Rust. Remote, building data-heavy products end to end."
+      content="Software engineer building production LLM/AI systems and geospatial/GPU visualization with deck.gl, luma.gl, and Rust."
     />
     <meta
       name="keywords"
@@ -40,18 +40,24 @@
     <meta property="og:title" content="John Carmack - AI/LLM & Geospatial Software Engineer" />
     <meta
       property="og:description"
-      content="Software engineer focused on production LLM/AI systems and geospatial/GPU visualization: deck.gl, luma.gl, Rust. Remote, building data-heavy products end to end."
+      content="Software engineer building production LLM/AI systems and geospatial/GPU visualization with deck.gl, luma.gl, and Rust."
     />
-    <meta property="og:image" content="/opengraph-image.png" />
+    <meta property="og:image" content="https://johncarmack.com/opengraph-image.png" />
+    <meta property="og:image:width" content="1280" />
+    <meta property="og:image:height" content="720" />
+    <meta property="og:image:type" content="image/png" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@johnmcarmack" />
+    <meta name="twitter:creator" content="@johnmcarmack" />
     <meta name="twitter:title" content="John Carmack - AI/LLM & Geospatial Software Engineer" />
     <meta
       name="twitter:description"
-      content="Software engineer focused on production LLM/AI systems and geospatial/GPU visualization: deck.gl, luma.gl, Rust. Remote, building data-heavy products end to end."
+      content="Software engineer building production LLM/AI systems and geospatial/GPU visualization with deck.gl, luma.gl, and Rust."
     />
-    <meta name="twitter:image" content="/opengraph-image.png" />
+    <meta name="twitter:image" content="https://johncarmack.com/opengraph-image.png" />
+    <meta name="twitter:image:alt" content="John Carmack - AI/LLM & Geospatial Software Engineer" />
 
     <link rel="canonical" href="https://johncarmack.com/" />
 

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "John Carmack",
   "short_name": "John Carmack",
-  "description": "Senior Software Engineer with 26 Years of Experience",
+  "description": "AI/LLM & Geospatial Software Engineer",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://johncarmack.com</loc>
-    <changefreq>daily</changefreq>
+    <loc>https://johncarmack.com/</loc>
+    <lastmod>2026-08-15</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

- Trim meta description to 118 chars (was 164, flagged by Ahrefs as >155)
- Make OG and Twitter image URLs absolute (`https://johncarmack.com/opengraph-image.png`) with `width`/`height`/`type`
- Add `twitter:site`, `twitter:creator` (`@johnmcarmack`), and `twitter:image:alt`
- Update stale manifest description ("Senior Software Engineer with 26 Years of Experience" → current positioning)
- Add `lastmod` to sitemap, fix `changefreq` to `weekly`

Addresses errors/warnings from Ahrefs Site Audit (Health Score 95, 3 errors + 8 warnings). Hosting-level findings (SPA fallback phantom pages, www→apex redirect) are noted but not in scope here.

## Test plan

- [ ] Build passes (`bun run check`)
- [ ] Deploy succeeds
- [ ] Validate OG tags: https://www.opengraph.xyz/url/https://johncarmack.com
- [ ] Validate Twitter card: https://cards-dev.twitter.com/validator
- [ ] Re-run Ahrefs crawl after deploy